### PR TITLE
Remove unused configuration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -137,8 +137,6 @@ whitelist_rules:
 analyzer_rules:
   - unused_declaration
   - unused_import
-force_cast: warning
-force_unwrapping: warning
 number_separator:
   minimum_length: 5
 object_literal:
@@ -164,4 +162,3 @@ identifier_name:
     - 'x2'
     - 'y1'
     - 'y2'
-


### PR DESCRIPTION
The `force_cast` and `force_unwrapping` rules are configured but not enabled (not in `whitelist_rules`):

```
❯ swiftlint
Loading configuration from '.swiftlint.yml'
Found a configuration for 'force_cast' rule, but it is not present on 'whitelist_rules'.
Found a configuration for 'force_unwrapping' rule, but it is not present on 'whitelist_rules'.
Linting Swift files at paths
...
```